### PR TITLE
Provide ext-mongo

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,5 +25,8 @@
         "alcaeus/mongo-php-adapter": "^1.1",
         "sonata-project/doctrine-mongodb-admin-bundle": "^3.1",
         "sonata-project/media-bundle": "^3.13"
+    },
+    "provide": {
+        "ext-mongo": "^1.6.14"
     }
 }


### PR DESCRIPTION
## Changelog

```markdown
### Added
- Added provide section with ext-mongo
```

## Subject

This package can not be installed with composer right now. All dependencies could be installed one by one, but not all together. With new `provide` section in composer.json this will be possible (somehow composer reads this section before other requirements).