### PR TITLE
Revert adding provide ext-mongo

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,8 +25,5 @@
         "alcaeus/mongo-php-adapter": "^1.1",
         "sonata-project/doctrine-mongodb-admin-bundle": "^3.1",
         "sonata-project/media-bundle": "^3.13"
-    },
-    "provide": {
-        "ext-mongo": "^1.6.14"
     }
 }


### PR DESCRIPTION
This PR reverts adding `provide` section to composer.json (#3  did not help)

I hope, recipe will be approved my somebody from Symfony core team even with failing travis